### PR TITLE
Remove bug from plotting functions

### DIFF
--- a/api-hackathon/graph_api.py
+++ b/api-hackathon/graph_api.py
@@ -168,8 +168,11 @@ def performQueryAnalysis(base_url, query_key, query_values):
 
 def plotData(plot_names, plot_data, title, filename):
     # Set up the plot
+    
     plt.rcParams.update({'figure.autolayout': True})
     fig, ax = plt.subplots()
+     # Remove warning
+    fig.set_tight_layout(False)
     # Make it a bar graph using the names and the data provided
     ax.barh(plot_names, plot_data)
     # Write the graph to the filename provided.

--- a/api-hackathon/heatmap_api.py
+++ b/api-hackathon/heatmap_api.py
@@ -131,6 +131,8 @@ def plotData(plot_data, xlabels, ylabels, title, filename):
     #matplotlib.use('Agg')
     plt.rcParams.update({'figure.autolayout': True})
     fig, ax = plt.subplots()
+    # Remove warning
+    fig.set_tight_layout(False)
     im = ax.imshow(plot_data)
     # Create colorbar
     cbar = ax.figure.colorbar(im, ax=ax)


### PR DESCRIPTION
Set tight layout to false and warning is gone. Tested both from Jupyter notebook and terminal. 

`fig.set_tight_layout(False)`

Warning was

```
/opt/conda/lib/python3.7/site-packages/matplotlib/figure.py:2369: UserWarning: This figure includes Axes that are not compatible with tight_layout, so results might be incorrect.
  warnings.warn("This figure includes Axes that are not compatible "
```